### PR TITLE
Fixes deprecation warning

### DIFF
--- a/custom_components/wavinsentio/climate.py
+++ b/custom_components/wavinsentio/climate.py
@@ -7,9 +7,8 @@ from homeassistant.components.climate import (
 
 from homeassistant.const import (
     ATTR_TEMPERATURE,
-    TEMP_CELSIUS,
+    UnitOfTemperature,  # Updated import
 )
-
 
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -23,7 +22,6 @@ PRESET_MODES = {
     "Extracomfort": {"profile": "extra"},
 }
 
-
 async def async_setup_entry(hass, entry, async_add_entities):
     dataservice = hass.data[DOMAIN].get("coordinator" + entry.data[CONF_LOCATION_ID])
 
@@ -34,7 +32,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
         ws = WavinSentioClimateEntity(hass, room, dataservice)
         entities.append(ws)
     async_add_entities(entities)
-
 
 class WavinSentioClimateEntity(CoordinatorEntity, ClimateEntity):
     """Representation of a Wavin Sentio Climate device."""
@@ -50,7 +47,7 @@ class WavinSentioClimateEntity(CoordinatorEntity, ClimateEntity):
         )
         self._preset_mode = None
         self._operation_list = None
-        self._unit_of_measurement = TEMP_CELSIUS
+        self._unit_of_measurement = UnitOfTemperature.CELSIUS 
         self._away = False
         self._on = True
         self._current_operation_mode = None

--- a/custom_components/wavinsentio/climate.py
+++ b/custom_components/wavinsentio/climate.py
@@ -7,7 +7,7 @@ from homeassistant.components.climate import (
 
 from homeassistant.const import (
     ATTR_TEMPERATURE,
-    UnitOfTemperature,  # Updated import
+    UnitOfTemperature,
 )
 
 from homeassistant.helpers.update_coordinator import (

--- a/custom_components/wavinsentio/sensor.py
+++ b/custom_components/wavinsentio/sensor.py
@@ -15,7 +15,7 @@ UPDATE_DELAY = timedelta(seconds=120)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    dataservice = hass.data[DOMAIN].get("coordinator" + entry.data[CONF_LOCATION_ID])
+    dataservice = hass.data[DOMAIN].get("coordinator"+entry.data[CONF_LOCATION_ID])
 
     outdoor_temperature_sensor = WavinSentioOutdoorTemperatureSensor(dataservice)
 

--- a/custom_components/wavinsentio/sensor.py
+++ b/custom_components/wavinsentio/sensor.py
@@ -50,7 +50,7 @@ class WavinSentioOutdoorTemperatureSensor(CoordinatorEntity, SensorEntity):
     @property
     def unit_of_measurement(self) -> str:
         """Return the unit of measurement."""
-        return UnitOfTemperature.CELSIUS  # Updated constant usage
+        return UnitOfTemperature.CELSIUS
 
     @property
     def device_class(self):

--- a/custom_components/wavinsentio/sensor.py
+++ b/custom_components/wavinsentio/sensor.py
@@ -3,7 +3,7 @@ import logging
 
 from homeassistant.components.sensor import SensorEntity
 
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -15,7 +15,7 @@ UPDATE_DELAY = timedelta(seconds=120)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    dataservice = hass.data[DOMAIN].get("coordinator"+entry.data[CONF_LOCATION_ID])
+    dataservice = hass.data[DOMAIN].get("coordinator" + entry.data[CONF_LOCATION_ID])
 
     outdoor_temperature_sensor = WavinSentioOutdoorTemperatureSensor(dataservice)
 
@@ -50,7 +50,7 @@ class WavinSentioOutdoorTemperatureSensor(CoordinatorEntity, SensorEntity):
     @property
     def unit_of_measurement(self) -> str:
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS  # Updated constant usage
 
     @property
     def device_class(self):


### PR DESCRIPTION
TEMP_CELSIUS was used from wavinsentio, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'wavinsentio' custom integration
